### PR TITLE
add support for github enterpirse and SSL configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,16 @@
                         "description": "Number of pull requests to show",
                         "type": "number",
                         "default": 6
+                    },
+                    "pullRequestMonitor.githubEnterpriseUrl": {
+                        "description": "The Url to a Github Enterprise",
+                        "type": "string",
+                        "default": null
+                    },
+                    "pullRequestMonitor.allowUnsafeSSL": {
+                        "description": "Stop the extension from verifying certs (turn on if you get an error)",
+                        "type": "boolean",
+                        "default": null
                     }
                 }
             }
@@ -103,6 +113,7 @@
         "eslint-plugin-import": "^2.13.0"
     },
     "dependencies": {
+        "https": "^1.0.0",
         "isomorphic-fetch": "^2.2.1",
         "vscode": "^1.1.18"
     },

--- a/src/extension.js
+++ b/src/extension.js
@@ -35,7 +35,17 @@ async function getPullRequests(context, showError) {
 		const showMerged = vscode.workspace.getConfiguration('pullRequestMonitor').get('showMerged');
 		const showClosed = vscode.workspace.getConfiguration('pullRequestMonitor').get('showClosed');
 		const count = vscode.workspace.getConfiguration('pullRequestMonitor').get('count');
-		const updatedPullRequests = await loadPullRequests(context.globalState.get('token'), { mode, showMerged, showClosed, repository, showError, count });
+		// configure the URL settings
+		let url = vscode.workspace.getConfiguration('pullRequestMonitor').get('githubEnterpriseUrl');
+		if (url) url = `${url}/api/graphql`;
+		// configure SSL
+		let allowUnsafeSSL = false;
+		if (vscode.workspace.getConfiguration('PullRequestMonitor').get('allowUnsafeSSL') === null) {
+			allowUnsafeSSL = vscode.workspace.getConfiguration('PullRequestMonitor').get('allowUnsafeSSL');
+		} else {
+			allowUnsafeSSL = !vscode.workspace.getConfiguration('https').get('proxyStrictSSL');
+		}
+		const updatedPullRequests = await loadPullRequests(context.globalState.get('token'), { mode, showMerged, showClosed, repository, showError, count, url, allowUnsafeSSL });
 		if (updatedPullRequests.code === 401) {
 			refreshButton.command = 'PullRequestMonitor.setToken';
 			refreshButton.text = '$(key)';


### PR DESCRIPTION
This allows the extension to user a user configured githubEnterpriseURL, as well as configure the HTTPS agent based on either application specific SSL settings or the http global settings for vscode.